### PR TITLE
Adding importance of ordering for resource mapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ where `physical_cpu` is the complex name:
 ]
 ```
 
-Ordering is also important when you want a particular behavior for a specific attribute, like a making sure
+Ordering is also important when you want a particular behavior for a specific attribute, like making sure
 only one slot will be allocate per node on a selected nodearray:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -210,6 +210,24 @@ where `physical_cpu` is the complex name:
 ]
 ```
 
+Ordering is also important when you want a particular behavior for a specific attribute, like a making sure
+only one slot will be allocate per node on a selected nodearray:
+
+```json
+    "default_resources": [
+    {
+      "select": {"node.nodearray": "FPGA"},
+      "name": "slots",
+      "value": "1",
+    },
+    {
+      "select": {},
+      "name": "slots",
+      "value": "node.vcpu_count"
+    },
+]
+```
+
 ## Hostgroups
 
 The CycleCloud autoscaler, in attempting to satisfy job requirements, will map nodes to


### PR DESCRIPTION
I had a customer that expended many days trying to customize his cluster deployment in order to obtain the right behavior from the autoscale service. We couldn't find any documentation about the ordering for attributes when you have multiple default resources with the same attribute. 