### PR TITLE
Ryhamel/fix drain race condition

### DIFF
--- a/gridengine/setup.py
+++ b/gridengine/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 from setuptools.command.test import Command
 from setuptools.command.test import test as TestCommand  # noqa: N812
 
-__version__ = "2.0.17"
+__version__ = "2.0.18"
 CWD = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/gridengine/src/version.py
+++ b/gridengine/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.17-SNAPSHOT"
+__version__ = "2.0.18-SNAPSHOT"

--- a/project.ini
+++ b/project.ini
@@ -2,11 +2,11 @@
 name = gridengine
 label = Grid Engine
 type = scheduler
-version = 2.0.17
+version = 2.0.18
 autoupgrade = true
 
 [blobs]
-Files=cyclecloud-gridengine-pkg-2.0.17.tar.gz, sge-2011.11-64.tgz, sge-2011.11-common.tgz
+Files=cyclecloud-gridengine-pkg-2.0.18.tar.gz, sge-2011.11-64.tgz, sge-2011.11-common.tgz
 
 [spec scheduler]
 run_list = role[central_manager],role[application_server],role[gridengine_scheduler_role],role[scheduler],role[monitor]

--- a/specs/default/chef/site-cookbooks/gridengine/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/gridengine/attributes/default.rb
@@ -3,7 +3,7 @@ default[:gridengine][:version] = "2011.11"
 default[:gridengine][:root] = "/sched/sge/sge-2011.11"
 default[:gridengine][:cell] = "default"
 default[:gridengine][:package_extension] = "tar.gz"
-default[:gridengine][:installer] = "cyclecloud-gridengine-pkg-2.0.17.tar.gz"
+default[:gridengine][:installer] = "cyclecloud-gridengine-pkg-2.0.18.tar.gz"
 default[:gridengine][:use_external_download] = false
 default[:gridengine][:remote_prefix] = nil
 

--- a/specs/default/chef/site-cookbooks/gridengine/metadata.rb
+++ b/specs/default/chef/site-cookbooks/gridengine/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "cyclecloud-support@cyclecomputing.com"
 license          "Apache 2.0"
 description      "Installs/Configures gridengine"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.17"
+version          "2.0.18"
 
 %w{ cuser cganglia cycle_server cshared cyclecloud }.each {|c| depends c }


### PR DESCRIPTION
After nodes are drained (i.e. their queues are disabled), check again that a job has not started running on them before the drain command complete before allowing them to be deleted.