### PR TITLE
Fix Python 3.8 issues

### DIFF
--- a/gridengine/setup.py
+++ b/gridengine/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 from setuptools.command.test import Command
 from setuptools.command.test import test as TestCommand  # noqa: N812
 
-__version__ = "2.0.19"
+__version__ = "2.0.20"
 CWD = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/gridengine/src/version.py
+++ b/gridengine/src/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.19-SNAPSHOT"
+__version__ = "2.0.20-SNAPSHOT"

--- a/install.sh
+++ b/install.sh
@@ -52,16 +52,9 @@ echo INSTALL_PYTHON3=$INSTALL_PYTHON3
 echo INSTALL_VIRTUALENV=$INSTALL_VIRTUALENV
 echo VENV=$VENV
 
-export PATH=$(python -c '
-import os
-paths = os.environ["PATH"].split(os.pathsep)
-cc_home = os.getenv("CYCLECLOUD_HOME", "/opt/cycle/jetpack")
-print(os.pathsep.join(
-    [p for p in paths if cc_home not in p]))')
+# DEPRECATED: For versions < 8.7.0: Remove any jetpack references from the path. 
+echo $PATH | sed -E -e 's/\/opt\/cycle\/jetpack\/[^:]*://g'
 
-
-echo $PATH > /tmp/debug_path.txt
-which python3 >> /tmp/debug_path.txt
 
 which python3 > /dev/null;
 if [ $? != 0 ]; then

--- a/install.sh
+++ b/install.sh
@@ -55,40 +55,51 @@ echo VENV=$VENV
 # DEPRECATED: For versions < 8.7.0: Remove any jetpack references from the path. 
 echo $PATH | sed -E -e 's/\/opt\/cycle\/jetpack\/[^:]*://g'
 
+# Require python3.8 - 3.12. Unfortunately the default python3 is 3.6 on alma 
+PYTHON_EXE=$(which python3.8 || which python3.9 || which python3.10 || which python3.11 || which python3.12 || which python3)
 
-which python3 > /dev/null;
+# if it does not exist, install it if the user requested it and then set PYTHON_EXE.
 if [ $? != 0 ]; then
     if [ $INSTALL_PYTHON3 == 1 ]; then
         $INSTALL_CMD install -y python3 || exit 1
+        PYTHON_EXE=$(which python3)
     else
-        echo Please install python3 >&2;
+        echo Please install python3.8 or newer >&2;
         exit 1
     fi
 fi
 
-python3 -m pip 2>&1 1> /dev/null
+# Make sure that the python version is supported.
+PYTHON_VERSION=$($PYTHON_EXE --version | awk '{print $2}')
+$PYTHON_EXE -c 'import sys; sys.exit(0 if sys.version_info >= (3,8) else 1)'
+if [ $? != 0 ]; then
+    echo "Python version $PYTHON_VERSION is not supported. Please install python3.8 or newer" >&2
+    exit 1
+fi
+
+$PYTHON_EXE -m pip 2>&1 1> /dev/null
 if [ $? != 0 ]; then
     if [ $INSTALL_PIP == 1 ]; then
-        $INSTALL_CMD install -y python3-pip || exit 1
+        $INSTALL_CMD install -y ${PYTHON_VERSION}-pip || exit 1
     else
-        echo Please install python3-pip >&2;
+        echo Please install ${PYTHON_VERSION}-pip >&2;
         exit 1
     fi
 fi
 
 
-python3 -m virtualenv --version 2>&1 > /dev/null
+$PYTHON_EXE -m virtualenv --version 2>&1 > /dev/null
 if [ $? != 0 ]; then
     if [ $INSTALL_VIRTUALENV ]; then
-        python3 -m pip install virtualenv || exit 1
+        $PYTHON_EXE -m pip install virtualenv || exit 1
     else
-        echo Please install virtualenv for python3 >&2
+        echo Please install virtualenv for $PYTHON_EXE >&2
         exit 1
     fi
 fi
 
 
-python3 -m virtualenv $VENV
+$PYTHON_EXE -m virtualenv $VENV
 source $VENV/bin/activate
 # not sure why but pip gets confused installing frozendict locally
 # if you don't install it first. It has no dependencies so this is safe.

--- a/package.py
+++ b/package.py
@@ -132,6 +132,9 @@ def execute() -> None:
         if fil.startswith("certifi-2019"):
             print("WARNING: Ignoring duplicate certifi {}".format(fil))
             continue
+        if "charset_normalizer" in fil:
+            print("WARNING: removing charset_normalizer")
+            continue
         path = os.path.join(build_dir, fil)
         _add("packages/" + fil, path)
 

--- a/package.py
+++ b/package.py
@@ -17,9 +17,15 @@ CYCLECLOUD_API_VERSION = "8.0.1"
 def build_sdist() -> str:
     cmd = [sys.executable, "setup.py", "sdist"]
     check_call(cmd, cwd=os.path.abspath("gridengine"))
-    sdists = glob.glob("gridengine/dist/cyclecloud-gridengine-*.tar.gz")
+    # see below for more: cyclecloud*gridengine so we cover cyclecloud-gridengine and cyclecloud_gridengine
+    sdists = glob.glob("gridengine/dist/cyclecloud*gridengine-*.tar.gz")
     assert len(sdists) == 1, "Found %d sdist packages, expected 1" % len(sdists)
     path = sdists[0]
+    # at some point setuptools changed the name of the sdist package to use underscores instead of dashes.
+    if "/cyclecloud_gridengine-" in path:
+        fixed_path = path.replace("/cyclecloud_gridengine-", "/cyclecloud-gridengine-")
+        os.rename(path, fixed_path)
+        path = fixed_path
     fname = os.path.basename(path)
     dest = os.path.join("libs", fname)
     if os.path.exists(dest):

--- a/project.ini
+++ b/project.ini
@@ -2,11 +2,11 @@
 name = gridengine
 label = Grid Engine
 type = scheduler
-version = 2.0.19
+version = 2.0.20
 autoupgrade = true
 
 [blobs]
-Files=cyclecloud-gridengine-pkg-2.0.19.tar.gz, sge-2011.11-64.tgz, sge-2011.11-common.tgz
+Files=cyclecloud-gridengine-pkg-2.0.20.tar.gz, sge-2011.11-64.tgz, sge-2011.11-common.tgz
 
 [spec scheduler]
 run_list = role[central_manager],role[application_server],role[gridengine_scheduler_role],role[scheduler],role[monitor]

--- a/specs/default/chef/site-cookbooks/gridengine/attributes/default.rb
+++ b/specs/default/chef/site-cookbooks/gridengine/attributes/default.rb
@@ -3,7 +3,7 @@ default[:gridengine][:version] = "2011.11"
 default[:gridengine][:root] = "/sched/sge/sge-2011.11"
 default[:gridengine][:cell] = "default"
 default[:gridengine][:package_extension] = "tar.gz"
-default[:gridengine][:installer] = "cyclecloud-gridengine-pkg-2.0.19.tar.gz"
+default[:gridengine][:installer] = "cyclecloud-gridengine-pkg-2.0.20.tar.gz"
 default[:gridengine][:use_external_download] = false
 default[:gridengine][:remote_prefix] = nil
 

--- a/specs/default/chef/site-cookbooks/gridengine/metadata.rb
+++ b/specs/default/chef/site-cookbooks/gridengine/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "cyclecloud-support@cyclecomputing.com"
 license          "Apache 2.0"
 description      "Installs/Configures gridengine"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.19"
+version          "2.0.20"
 
 %w{ cuser cganglia cycle_server cshared cyclecloud }.each {|c| depends c }

--- a/templates/altair-grid-engine.txt
+++ b/templates/altair-grid-engine.txt
@@ -465,21 +465,21 @@ Order = 20
         [[[parameter SchedulerImageName]]]
         Label = Scheduler Base OS
         ParameterType = Cloud.Image
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.centos8", "almalinux8"}
+        Config.Filter := Package in {"almalinux8"}
         Config.OS = linux
         DefaultValue = almalinux8
 
         [[[parameter HPCImageName]]]
         Label = HPC Base OS
         ParameterType = Cloud.Image
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.centos8", "almalinux8"}
+        Config.Filter := Package in {"almalinux8"}
         Config.OS = linux
         DefaultValue = almalinux8
 
         [[[parameter HTCImageName]]]
         Label = HTC Base OS
         ParameterType = Cloud.Image
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.centos8", "almalinux8"}
+        Config.Filter := Package in {"almalinux8"}
         Config.OS = linux
         DefaultValue = almalinux8
 

--- a/templates/gridengine.txt
+++ b/templates/gridengine.txt
@@ -392,21 +392,21 @@ Order = 20
         [[[parameter SchedulerImageName]]]
         Label = Scheduler Base OS
         ParameterType = Cloud.Image
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.centos8", "almalinux8"}
+        Config.Filter := Package in {"almalinux8"}
         Config.OS = linux
         DefaultValue = almalinux8
 
         [[[parameter HPCImageName]]]
         Label = HPC Base OS
         ParameterType = Cloud.Image
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.centos8", "almalinux8"}
+        Config.Filter := Package in {"almalinux8"}
         Config.OS = linux
         DefaultValue = almalinux8
 
         [[[parameter HTCImageName]]]
         Label = HTC Base OS
         ParameterType = Cloud.Image
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.centos8", "almalinux8"}
+        Config.Filter := Package in {"almalinux8"}
         Config.OS = linux
         DefaultValue = almalinux8
 


### PR DESCRIPTION
Python 3.8+ is required due to requests changes.
Remove conflicting, unneeded charset package.
Remove python based logic of stripping jetpack embedded python from the PATH and replace it with sed.
Bump version to 2.0.20